### PR TITLE
fix: Railway kpi fixes and improvements

### DIFF
--- a/ai4realnet_orchestrators/railway/abstract_test_runner_railway.py
+++ b/ai4realnet_orchestrators/railway/abstract_test_runner_railway.py
@@ -25,6 +25,10 @@ class AbtractTestRunnerRailway(TestRunner):
       args = ["docker", "run", "--rm", "-v", f"{DATA_VOLUME}:/vol", "alpine:latest", "chmod", "-R", "a=rwx",
               f"/vol/{submission_id}/{self.test_id}/{scenario_id}"]
       exec_with_logging(args if not SUDO else ["sudo"] + args)
+
+      # update image
+      args = ["docker", "pull", self.submission_data_url, ]
+      exec_with_logging(args if not SUDO else ["sudo"] + args)
       args = [
                "docker", "run",
                "--rm",

--- a/ai4realnet_orchestrators/railway/test_runner_kpi_nf_045_railway.py
+++ b/ai4realnet_orchestrators/railway/test_runner_kpi_nf_045_railway.py
@@ -58,7 +58,8 @@ class TestRunner_KPI_NF_045_Railway(AbtractTestRunnerRailway):
       "--effects-generator-kwargs", "condition_pkg", "flatland.envs.malfunction_effects_generators",
       "--effects-generator-kwargs", "condition_cls", "on_map_state_condition",
       "--ep-id", scenario_id,
-      "--env-path", f"{SCENARIOS_VOLUME_MOUNTPATH}/{env_path}"
+      "--env-path", f"{SCENARIOS_VOLUME_MOUNTPATH}/{env_path}",
+      "--snapshot-interval", "10",
     ]
     self.exec(generate_policy_args_one_malfunction, scenario_id, submission_id, f"{submission_id}/{self.test_id}/{scenario_id}/with_malfunction")
 

--- a/ai4realnet_orchestrators/railway/test_runner_kpi_nf_045_railway.py
+++ b/ai4realnet_orchestrators/railway/test_runner_kpi_nf_045_railway.py
@@ -106,8 +106,9 @@ class TestRunner_KPI_NF_045_Railway(AbtractTestRunnerRailway):
     betroffen2 = [num_punctual != num_waypoints for num_punctual, num_waypoints in punctuality_tuples_with_malfunction]
     num_betroffen2 = np.sum(betroffen2)
     logger.info(f"num_betroffen2 {num_betroffen2}")
-    nip = 1 - ((num_betroffen2 - num_betroffen1) / num_agents)
-    logger.info(f"network impact propagation {nip} = (1 - ({num_betroffen2}-{num_betroffen1}) / {num_agents})")
+    unclipped = 1 - ((num_betroffen2 - num_betroffen1) / num_agents)
+    nip = np.clip(unclipped, 0, 1)
+    logger.info(f"network impact propagation {nip} np.clip({unclipped}, 0, 1) = np.clip(1 - ({num_betroffen2}-{num_betroffen1}) / {num_agents}, 0, 1)")
 
     assert nip >= 0
     assert nip <= 1

--- a/ai4realnet_orchestrators/railway/test_runner_kpi_pf_026_railway.py
+++ b/ai4realnet_orchestrators/railway/test_runner_kpi_pf_026_railway.py
@@ -28,7 +28,8 @@ class TestRunner_KPI_PF_026_Railway(AbtractTestRunnerRailway):
       "--obs-builder-pkg", "flatland_baselines.deadlock_avoidance_heuristic.observation.full_env_observation", "--obs-builder-cls", "FullEnvObservation",
       "--rewards-pkg", "flatland.envs.rewards", "--rewards-cls", "PunctualityRewards",
       "--ep-id", scenario_id,
-      "--env-path", f"{SCENARIOS_VOLUME_MOUNTPATH}/{env_path}"
+      "--env-path", f"{SCENARIOS_VOLUME_MOUNTPATH}/{env_path}",
+      "--snapshot-interval", "10",
     ]
     self.exec(generate_policy_args, scenario_id, submission_id, f"{submission_id}/{self.test_id}/{scenario_id}")
 


### PR DESCRIPTION
**Changes**
*  feat(railway test runners): docker pull submission data every time.
* feat(railway test runners): clip network impact definition values to [0,1].
*  feat(railway test runners): reduce snapshot interval.

Follow-up of #12 
Relates to https://github.com/flatland-association/flatland-benchmarks/issues/248
Relates to https://github.com/flatland-association/flatland-benchmarks/issues/401
